### PR TITLE
fix: rename conflicting template project name

### DIFF
--- a/bin/templates/basic/package.json
+++ b/bin/templates/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic",
+  "name": "basic_template",
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {


### PR DESCRIPTION
Just renames the project name in the basic template package.json